### PR TITLE
CptLoader::load() - up to 100 records in the tail of the files may not be saved in the database

### DIFF
--- a/src/main/java/org/sitenv/vocabularies/loader/code/CptLoader.java
+++ b/src/main/java/org/sitenv/vocabularies/loader/code/CptLoader.java
@@ -31,7 +31,8 @@ public class CptLoader extends BaseCodeLoader {
         FileReader fileReader = null;
         try {
             StrBuilder insertQueryBuilder = new StrBuilder(codeTableInsertSQLPrefix);
-            int totalCount = 0, pendingCount = 0;
+            int totalCount = 0; 
+            boolean isPending = false;
 
             for (File file : filesToLoad) {
                 if (file.isFile() && !file.isHidden()) {
@@ -45,18 +46,19 @@ public class CptLoader extends BaseCodeLoader {
                             String code = line.substring(0, 5);
                             String displayName = isTabDelimitedFile(line) ? line.substring(line.indexOf('\t')) : line.substring(line.indexOf(" "));
                             buildCodeInsertQueryString(insertQueryBuilder, code, displayName, codeSystem, oid, CODES_IN_THIS_SYSTEM_ARE_ALWAYS_ACTIVE);
+                            isPending = true;
 
                             if ((++totalCount % BATCH_SIZE) == 0) {
                                 insertCode(insertQueryBuilder.toString(), connection);
                                 insertQueryBuilder.clear();
                                 insertQueryBuilder.append(codeTableInsertSQLPrefix);
-                                pendingCount = 0;
+                                isPending = false;
                             }
                         }
                     }
                 }
             }
-            if (pendingCount > 0) {
+            if (isPending) {
                 insertCode(insertQueryBuilder.toString(), connection);
             }
         } catch (IOException e) {


### PR DESCRIPTION
In the loader CPT files to the internal database аn error occurs, as a result of which the last batch of data
is not entered into the database (lost) and, accordingly, is not used for processing:
![image](https://user-images.githubusercontent.com/86000550/122376656-04921700-cf6d-11eb-9de8-4b1f28a07128.png)
As we can see in the debug screenshot, the **insertQueryBuilder** variable contains the last chunk of data,
but the **insertCode()** method to enter the database is never executed, because as a result of a code implementation error,
the **pendingCount** counter is never modified (always 0).