### PR TITLE
Fix FWK005 Exception during parallel execution of DocumentBuilder

### DIFF
--- a/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
+++ b/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
-import javax.xml.parsers.DocumentBuilder;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathFactory;
@@ -131,10 +131,18 @@ public class CodeValidatorApiConfiguration {
     }
 
     @Bean
-    public DocumentBuilder documentBuilder() throws ParserConfigurationException {
-        DocumentBuilderFactory domFactory =  DocumentBuilderFactory.newInstance();
+    public DocumentBuilderFactory documentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory domFactory =  DocumentBuilderFactory.newInstance("com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl", ClassLoader.getSystemClassLoader());
+        domFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        domFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        domFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        domFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        domFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        domFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        domFactory.setXIncludeAware(false);
+        domFactory.setExpandEntityReferences(false);
         domFactory.setNamespaceAware(true);
-        return domFactory.newDocumentBuilder();
+        return domFactory;
     }
 
     @Bean

--- a/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
@@ -13,6 +13,8 @@ import javax.annotation.Resource;
 import javax.servlet.ServletContext;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -47,8 +49,8 @@ import org.xml.sax.SAXException;
 public class VocabularyValidationService {
     @Resource(name="vocabularyValidationConfigurations")
     List<ConfiguredExpression> vocabularyValidationConfigurations;
-    @Resource(name="documentBuilder")
-    DocumentBuilder documentBuilder;
+	@Autowired
+	private DocumentBuilderFactory documentBuilderFactory;
     @Resource(name="xPathFactory")
     XPathFactory xPathFactory;
     @Autowired
@@ -58,7 +60,7 @@ public class VocabularyValidationService {
     @Resource(name="globalCodeValidatorResults")
     GlobalCodeValidatorResults globalCodeValidatorResults;
     
-    private static Logger logger = Logger.getLogger(VocabularyValidationService.class);
+    private static final Logger logger = Logger.getLogger(VocabularyValidationService.class);
     private static final boolean FULL_LOG = false;
     
     public List<VocabularyValidationResult> validate(String uri) throws IOException, SAXException {
@@ -71,9 +73,15 @@ public class VocabularyValidationService {
 
 	public List<VocabularyValidationResult> validate(String uri, String vocabularyConfig, SeverityLevel severityLevel)
 			throws IOException, SAXException {
-        Document doc = documentBuilder.parse(uri);
-        return this.validate(doc, vocabularyConfig, severityLevel);
-    }
+		DocumentBuilder documentBuilder;
+		try {
+			documentBuilder = documentBuilderFactory.newDocumentBuilder();
+		} catch (ParserConfigurationException e) {
+			throw new RuntimeException("ERROR creating DocumentBuilder " + e.getMessage());
+		}
+		Document doc = documentBuilder.parse(uri);
+		return this.validate(doc, vocabularyConfig, severityLevel);
+	}
 
     public List<VocabularyValidationResult> validate(InputStream stream) throws IOException, SAXException {
     	return this.validate(stream, VocabularyConstants.Config.DEFAULT);
@@ -83,12 +91,18 @@ public class VocabularyValidationService {
 			throws IOException, SAXException {
 		return validate(stream, vocabularyConfig, SeverityLevel.INFO);
     }
-	
+
 	public List<VocabularyValidationResult> validate(InputStream stream, String vocabularyConfig, SeverityLevel severityLevel)
 			throws IOException, SAXException {
-        Document doc = documentBuilder.parse(stream);
-        return this.validate(doc, vocabularyConfig, severityLevel);
-    }
+		DocumentBuilder documentBuilder;
+		try {
+			documentBuilder = documentBuilderFactory.newDocumentBuilder();
+		} catch (ParserConfigurationException e) {
+			throw new RuntimeException("ERROR creating DocumentBuilder " + e.getMessage());
+		}
+		Document doc = documentBuilder.parse(stream);
+		return this.validate(doc, vocabularyConfig, severityLevel);
+	}
 
 	public List<VocabularyValidationResult> validate(Document doc) {
 		return this.validate(doc, VocabularyConstants.Config.DEFAULT);

--- a/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
+++ b/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.ServletContext;
-import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathFactory;
 
@@ -35,7 +35,7 @@ public class VocabularyValidationTester {
 	private TestableVocabularyValidationService vocabularyValidationService;
 
 	List<ConfiguredExpression> vocabularyValidationConfigurations;
-	DocumentBuilder documentBuilder;
+	private DocumentBuilderFactory documentBuilderFactory;
 	XPathFactory xPathFactory;
 	NodeValidatorFactory vocabularyValidatorFactory;
 	ServletContext context;
@@ -50,7 +50,7 @@ public class VocabularyValidationTester {
 	private void intializeVocabularyValidationServiceFields() {
 		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
 		try {
-			documentBuilder = codeValidatorConfig.documentBuilder();
+			documentBuilderFactory = codeValidatorConfig.documentBuilderFactory();
 		} catch (ParserConfigurationException e) {
 			e.printStackTrace();
 		}
@@ -107,7 +107,7 @@ public class VocabularyValidationTester {
 		vocabularyValidationService = new TestableVocabularyValidationService();
 		ReflectionTestUtils.setField(vocabularyValidationService, "vocabularyValidationConfigurations",
 				vocabularyValidationConfigurations);
-		ReflectionTestUtils.setField(vocabularyValidationService, "documentBuilder", documentBuilder);
+		ReflectionTestUtils.setField(vocabularyValidationService, "documentBuilderFactory", documentBuilderFactory);
 		ReflectionTestUtils.setField(vocabularyValidationService, "xPathFactory", xPathFactory);
 		ReflectionTestUtils.setField(vocabularyValidationService, "vocabularyValidatorFactory",
 				vocabularyValidatorFactory);


### PR DESCRIPTION
Neither **DocumentBuilderFactory** nor **DocumentBuilder** are guaranteed to be **thread-safe**
If we have several **threads** parsing XML, we need to make sure that each thread has its own version of DocumentBuilder.
We only need one of them per **Thread** since we can reuse a DocumentBuilder after we reset it.
