### PR TITLE
The configuredExpressions variable has wrong values quantity in case …

### DIFF
--- a/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
+++ b/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
@@ -1,5 +1,6 @@
 package org.sitenv.vocabularies.configuration;
 
+import org.sitenv.vocabularies.constants.VocabularyConstants;
 import org.sitenv.vocabularies.loader.VocabularyLoadRunner;
 import org.sitenv.vocabularies.loader.VocabularyLoaderFactory;
 import org.sitenv.vocabularies.validation.NodeValidatorFactory;
@@ -27,10 +28,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathFactory;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * Created by Brian on 2/5/2016.
@@ -126,8 +124,44 @@ public class CodeValidatorApiConfiguration {
     }
 
     @Bean
-    public static List<ConfiguredExpression> vocabularyValidationConfigurations(ValidationConfigurationLoader configurationLoader){
-        return configurationLoader.getConfigurations().getExpressions();
+    public static Map<VocabularyConstants.SeverityLevel, List<ConfiguredExpression>> vocabularyValidationConfigurations(ValidationConfigurationLoader configurationLoader){
+        // This improves performance since it is run before the expressions are processed
+        List<ConfiguredExpression> configuredExpressionList = configurationLoader.getConfigurations().getExpressions();
+
+        Map<VocabularyConstants.SeverityLevel, List<ConfiguredExpression>> expressionsMap = new HashMap<>();
+        expressionsMap.put(VocabularyConstants.SeverityLevel.INFO, configuredExpressionList);
+        expressionsMap.put(VocabularyConstants.SeverityLevel.WARNING, new ArrayList<>());
+        expressionsMap.put(VocabularyConstants.SeverityLevel.ERROR, new ArrayList<>());
+
+        List<ConfiguredExpression> warningLevelConfiguredExpressions = expressionsMap.get(VocabularyConstants.SeverityLevel.WARNING);
+        List<ConfiguredExpression> errorLevelConfiguredExpressions = expressionsMap.get(VocabularyConstants.SeverityLevel.ERROR);
+
+        for (ConfiguredExpression configuredExpression : configuredExpressionList) {
+            // NodeCodeSystemMatchesConfiguredCodeSystemValidator defaults to ERROR severity dynamically
+            configuredExpression.getConfiguredValidators().parallelStream()
+                    .filter(configuredValidator -> !configuredValidator.getName().equalsIgnoreCase("NodeCodeSystemMatchesConfiguredCodeSystemValidator"))
+                    .map(configuredValidator -> configuredValidator.getConfiguredValidationResultSeverityLevel().getSeverityLevelConversion())
+                    .forEach(configuredSeverityLevelConversion -> {
+                        // skip may/info configurations so we only process warnings and errors
+                        if (configuredSeverityLevelConversion != VocabularyConstants.SeverityLevel.INFO) {
+                            warningLevelConfiguredExpressions.add(configuredExpression);
+                        }
+                        // skip may/info and should/warnings configurations so we only process errors
+                        if (configuredSeverityLevelConversion == VocabularyConstants.SeverityLevel.ERROR) {
+                            errorLevelConfiguredExpressions.add(configuredExpression);
+                        }
+                    });
+        }
+        expressionsMap.forEach((k, v) -> {
+            Iterator<ConfiguredExpression> expressionIter = v.iterator();
+            while (expressionIter.hasNext()) {
+                ConfiguredExpression configuredExpression = expressionIter.next();
+                if (configuredExpression.getConfiguredValidators().isEmpty()) {
+                    expressionIter.remove();
+                }
+            }
+        });
+        return expressionsMap;
     }
 
     @Bean

--- a/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
+++ b/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
@@ -28,7 +28,12 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Created by Brian on 2/5/2016.

--- a/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
@@ -1,7 +1,11 @@
 package org.sitenv.vocabularies.validation.services;
 
 import org.apache.log4j.Logger;
-import org.sitenv.vocabularies.configuration.*;
+import org.sitenv.vocabularies.configuration.CodeValidatorApiConfiguration;
+import org.sitenv.vocabularies.configuration.Configurations;
+import org.sitenv.vocabularies.configuration.ConfiguredExpression;
+import org.sitenv.vocabularies.configuration.ConfiguredValidator;
+import org.sitenv.vocabularies.configuration.ValidationConfigurationLoader;
 import org.sitenv.vocabularies.constants.VocabularyConstants;
 import org.sitenv.vocabularies.constants.VocabularyConstants.LogSeverity;
 import org.sitenv.vocabularies.constants.VocabularyConstants.SeverityLevel;
@@ -29,7 +33,11 @@ import javax.xml.xpath.XPathFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Brian on 2/10/2016.

--- a/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
+++ b/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
@@ -22,7 +22,11 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
 

--- a/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
+++ b/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
@@ -1,18 +1,5 @@
 package org.sitenv.vocabularies.test.other;
 
-import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.servlet.ServletContext;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathFactory;
-
 import org.junit.Before;
 import org.sitenv.vocabularies.configuration.CodeValidatorApiConfiguration;
 import org.sitenv.vocabularies.configuration.ConfiguredExpression;
@@ -29,12 +16,22 @@ import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.xml.sax.SAXException;
 
+import javax.servlet.ServletContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+
+import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
+
 public class VocabularyValidationTester {
 
 	private CodeValidatorApiConfiguration codeValidatorConfig;
 	private TestableVocabularyValidationService vocabularyValidationService;
 
-	List<ConfiguredExpression> vocabularyValidationConfigurations;
+	Map<SeverityLevel, List<ConfiguredExpression>> vocabularyValidationConfigurations;
 	DocumentBuilder documentBuilder;
 	XPathFactory xPathFactory;
 	NodeValidatorFactory vocabularyValidatorFactory;
@@ -48,7 +45,7 @@ public class VocabularyValidationTester {
 	}
 
 	private void intializeVocabularyValidationServiceFields() {
-		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
+		vocabularyValidationConfigurations = new HashMap<>();
 		try {
 			documentBuilder = codeValidatorConfig.documentBuilder();
 		} catch (ParserConfigurationException e) {
@@ -75,7 +72,7 @@ public class VocabularyValidationTester {
 			context.setInitParameter("referenceccda.isDynamicVocab", "false");
 		}
 	}
-	
+
 	public static ConfiguredExpression createConfiguredExpression(String validatorName, ConfiguredValidationResultSeverityLevel severity,
 			String requiredNodeName, String validationMessage, String configuredXpathExpression) {
 		ConfiguredValidator configuredValidator = new ConfiguredValidator();
@@ -85,22 +82,17 @@ public class VocabularyValidationTester {
 		configuredValidator.setValidationMessage(validationMessage);
 		ConfiguredExpression configuredExpression = new ConfiguredExpression();
 		configuredExpression
-				.setConfiguredValidators(new ArrayList<ConfiguredValidator>(Arrays.asList(configuredValidator)));
+				.setConfiguredValidators(new ArrayList<>(Collections.singletonList(configuredValidator)));
 		configuredExpression.setConfiguredXpathExpression(configuredXpathExpression);
 		return configuredExpression;
 	}
 
 	public void programmaticallyConfigureRequiredNodeValidator(ConfiguredValidationResultSeverityLevel severity,
-			String requiredNodeName, String validationMessage, String configuredXpathExpression) {		
+															   String requiredNodeName, String validationMessage, String configuredXpathExpression) {
 		ConfiguredExpression configuredExpression = createConfiguredExpression("RequiredNodeValidator", severity,
-				requiredNodeName, validationMessage, configuredXpathExpression);		
-		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
-		vocabularyValidationConfigurations.addAll(Arrays.asList(configuredExpression));
-	}
-	
-	public void addConfiguredExpressionsToVocabularyValidationConfigurations (List<ConfiguredExpression> configuredExpressions) {
-		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
-		vocabularyValidationConfigurations.addAll(configuredExpressions);
+				requiredNodeName, validationMessage, configuredXpathExpression);
+		vocabularyValidationConfigurations = new HashMap<>();
+		vocabularyValidationConfigurations.put(severity.getSeverityLevelConversion(), Collections.singletonList(configuredExpression));
 	}
 
 	public void injectDependencies() {
@@ -124,6 +116,10 @@ public class VocabularyValidationTester {
 		return testVocabularyValidator(filePath, vocabularyConfig, SeverityLevel.INFO);
 	}
 
+	public List<VocabularyValidationResult> testVocabularyValidator(URI filePath, SeverityLevel severityLevel) {
+		return testVocabularyValidator(filePath, VocabularyConstants.Config.DEFAULT, severityLevel);
+	}
+
 	public List<VocabularyValidationResult> testVocabularyValidator(URI filePath, String vocabularyConfig,
 			SeverityLevel severityLevel) {
 		List<VocabularyValidationResult> results = new ArrayList<>();
@@ -136,9 +132,7 @@ public class VocabularyValidationTester {
 			for (VocabularyValidationResult result : results) {
 				println(result.toString());
 			}
-		} catch (IOException e) {
-			e.printStackTrace();
-		} catch (SAXException e) {
+		} catch (IOException | SAXException e) {
 			e.printStackTrace();
 		}
 		return results;
@@ -170,7 +164,7 @@ public class VocabularyValidationTester {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return a testable version of VocabularyValidationService. *Note*: This
 	 *         is NULL without initialize(), setupInitParameters(x),
 	 *         injectDependencies(); i.e. it must be setup the same as any other

--- a/src/test/java/org/sitenv/vocabularies/test/tests/VocabularyValidationServiceTest.java
+++ b/src/test/java/org/sitenv/vocabularies/test/tests/VocabularyValidationServiceTest.java
@@ -1,12 +1,5 @@
 package org.sitenv.vocabularies.test.tests;
 
-import static org.sitenv.vocabularies.test.other.ValidationLogger.logResults;
-import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-
 import org.apache.log4j.BasicConfigurator;
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,6 +12,13 @@ import org.sitenv.vocabularies.test.other.ValidationTest;
 import org.sitenv.vocabularies.test.other.VocabularyValidationTester;
 import org.sitenv.vocabularies.validation.dto.VocabularyValidationResult;
 import org.sitenv.vocabularies.validation.dto.enums.VocabularyValidationResultLevel;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static org.sitenv.vocabularies.test.other.ValidationLogger.logResults;
+import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
 
 public class VocabularyValidationServiceTest extends VocabularyValidationTester implements ValidationTest {
 
@@ -62,11 +62,12 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 		String configuredXpathExpression = "//v3:observation/v3:templateId[@root='2.16.840.1.113883.10.20.22.4.2' and @extension='2015-08-01']"
 				+ "/ancestor::v3:observation[1]/v3:value"
 				+ "[@xsi:type='PQ' and not(@nullFlavor) and ancestor::v3:section[not(@nullFlavor)]]";
-		programmaticallyConfigureRequiredNodeValidator(new ConfiguredValidationResultSeverityLevel("SHALL"), "@unit",
+		ConfiguredValidationResultSeverityLevel severityLevel = new ConfiguredValidationResultSeverityLevel("SHALL");
+		programmaticallyConfigureRequiredNodeValidator(severityLevel, "@unit",
 				validationMessage, configuredXpathExpression);
 		injectDependencies();
 
-		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE]);
+		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], severityLevel.getSeverityLevelConversion());
 
 		Assert.assertTrue(ASSERT_MSG_NO_VOCABULARY_ISSUE_BUT_SHOULD, hasVocabularyIssue(results));
 		String expectedMessage = "The node '@unit' does not exist at the expected path "
@@ -80,7 +81,7 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 		 * classCode="OBS" moodCode="EVN"> ... <value xsi:type="PQ"
 		 * value="1.015" unit="someUnit"/> ... </observation>
 		 */
-		results = testVocabularyValidator(CCDA_FILES[HAS_UNIT_ATTRIBUTE]);
+		results = testVocabularyValidator(CCDA_FILES[HAS_UNIT_ATTRIBUTE], severityLevel.getSeverityLevelConversion());
 
 		Assert.assertFalse(ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT, hasVocabularyIssue(results));
 		Assert.assertFalse(ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT,
@@ -135,7 +136,7 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 		programmaticallyConfigureRequiredNodeValidator(severity, element, validationMessage, configuredXpathExpression);
 		injectDependencies();
 
-		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE]);
+		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], severity.getSeverityLevelConversion());
 
 		Assert.assertTrue(ASSERT_MSG_NO_VOCABULARY_ISSUE_BUT_SHOULD, hasVocabularyIssue(results));
 		String expectedMessage = "The node 'v3:prefix' does not exist at the expected path "
@@ -154,7 +155,7 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 		programmaticallyConfigureRequiredNodeValidator(severity, element, validationMessage, configuredXpathExpression);
 		injectDependencies();
 
-		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE]);
+		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], severity.getSeverityLevelConversion());
 
 		Assert.assertFalse(ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT, hasVocabularyIssue(results));
 		expectedMessage = "The node 'v3:prefix' does not exist at the expected path "


### PR DESCRIPTION
The configuredExpressions variable has wrong values quantity in case we want to validate same document more than two times with the different severity level.

Validation iterations:
1) Use INFO level - configuredExpressions list has 180 elements.
2) Use ERROR level - configuredExpressions list has 120 elements.
3) Use INFO level again - configuredExpressions list has 120 elements. Not 180 as it was before ERROR.
In this case we can add a new list as a local variable and add suitable ConfiguredExpressions to it for each validation process.