### PR TITLE
Fix OWASP Critical Vulnerability in dependency xmlbeans-2.6.0.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>3.17</version>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.monitorjbl</groupId>


### PR DESCRIPTION
Dependency: xmlbeans-2.6.0.jar
Vulnerability IDs: cpe:2.3:a:apache:xmlbeans:2.6.0:*:*:*:*:*:*:*
Package: pkg:maven/org.apache.xmlbeans/xmlbeans@2.6.0
Highest Severity: CRITICAL

xmlbeans@2.6.0 is introduced by poi-ooxml@3.17. On upgrading to poi-ooxml@4.0.0 we get xmlbeans@3.0.0 which does not have any OWASP vulnerability 
